### PR TITLE
alpha-test before attempting to calculate shadow values

### DIFF
--- a/shaders_shader_passes_shadow_shadow_apply_combined_1.psh
+++ b/shaders_shader_passes_shadow_shadow_apply_combined_1.psh
@@ -23,60 +23,67 @@ float4 main(
 ) : COLOR
 {
     float4 r0 = 0;
-    float2 texelSize = 1.0 / float2(1024, 1024); // Shadow map resolution
+	
+	// check alpha first before doing anything
+	// branch divergence shouldn't be any slower than just doing
+	// both sides of the branch, but if alpha is below 0.5 across a whole warp
+	// this will save processing time wasted computing the shadows
+	if (color0.a > 0.5)
+        float2 texelSize = 1.0 / float2(1024, 1024); // Shadow map resolution
+    
+        // Base texture coordinate for shadow map sampling
+        float4 baseTC = tc[0];
+	
+	    // shadow buffer
+	    sampler2D shadow_buffer = s0;
 
-    // Base texture coordinate for shadow map sampling
-    float4 baseTC = tc[0];
+        // Bias term to reduce self-shadowing artifacts
+        float bias = 0.00015;  // Adjust to your liking but be careful, or you'll get peter-panning
 
-    // Bias term to reduce self-shadowing artifacts
-    float bias = 0.00015;  // Adjust to your liking but be careful, or you'll get peter-panning
+        // Poisson Disk Offsets
+        float2 poissonDisk[12] = {
+            float2(-0.94201624, -0.39906216),
+            float2(0.94558609, -0.76890725),
+            float2(-0.094184101, -0.92938870),
+            float2(0.34495938, 0.29387760),
+            float2(-0.91588581, 0.45771432),
+            float2(-0.81544232, -0.87912464),
+            float2(-0.38277543, 0.27676845),
+            float2(0.97484398, 0.75648379),
+            float2(0.44323325, -0.97511554),
+            float2(0.53742981, -0.47373420),
+            float2(-0.26496911, -0.41893023),
+            float2(0.79197514, 0.19090188)
+        };
 
-    // Poisson Disk Offsets
-    float2 poissonDisk[12] = {
-        float2(-0.94201624, -0.39906216),
-        float2(0.94558609, -0.76890725),
-        float2(-0.094184101, -0.92938870),
-        float2(0.34495938, 0.29387760),
-        float2(-0.91588581, 0.45771432),
-        float2(-0.81544232, -0.87912464),
-        float2(-0.38277543, 0.27676845),
-        float2(0.97484398, 0.75648379),
-        float2(0.44323325, -0.97511554),
-        float2(0.53742981, -0.47373420),
-        float2(-0.26496911, -0.41893023),
-        float2(0.79197514, 0.19090188)
-    };
-
-    // Combined Poisson Disk Sampling and 5-tap PCF
-    for (int i = -2; i <= 2; ++i)
-    {
-        for (int j = -2; j <= 2; ++j)
+        // Combined Poisson Disk Sampling and 5-tap PCF
+        for (int i = -2; i <= 2; ++i)
         {
-            float2 pcfOffset = float2(i, j) * texelSize;
-            for (int k = 0; k < 12; ++k)
+            for (int j = -2; j <= 2; ++j)
             {
-                float2 poissonOffset = poissonDisk[k] * texelSize;
-                float2 combinedOffset = pcfOffset + poissonOffset;
-                float4 newTC = baseTC;
-                newTC.xy += combinedOffset;
-                float depth = DX11_tex2Dproj(s0, newTC).r;
+                float2 pcfOffset = float2(i, j) * texelSize;
+                for (int k = 0; k < 12; ++k)
+                {
+                    float2 poissonOffset = poissonDisk[k] * texelSize;
+                    float2 combinedOffset = pcfOffset + poissonOffset;
+                    float4 newTC = baseTC;
+                    newTC.xy += combinedOffset;
+                    float depth = DX11_tex2Dproj(s0, newTC).r;
 
-                // Magic happens here
-                if ((newTC.b / newTC.a) - bias < depth)
-                    r0 += 1.0f / (25.0f * 12.0f);  // Normalize by the number of samples
+                    // Magic happens here
+                    if ((newTC.b / newTC.a) - bias < depth)
+                        r0 += 1.0f / (25.0f * 12.0f);  // Normalize by the number of samples
+                }
             }
         }
-    }
 
-    // Existing shader code for shadow fade
-    r0 = c2.a * r0 + (1 - c2.a);
+        // Existing shader code for shadow fade
+        r0 = c2.a * r0 + (1 - c2.a);
 
-    // Existing shader code for fog
-    float4 tex3 = DX11_tex2Dproj(s1, tc3);
-    r0 *= tex3.bbbb;
-
-    // Existing shader code for color
-    if (color0.a <= 0.5) {
+        // Existing shader code for fog
+        float4 tex3 = DX11_tex2Dproj(s1, tc3);
+        r0 *= tex3.bbbb;
+    else {
         r0 = 0;
     }
 


### PR DESCRIPTION
if the alpha-test failed the shader would waste a lot of time calculating the shadows just for the result to be thrown away.

Maybe the compiler already optimized this or that test doesn't fail often enough for it to matter but might as well move the conditional to a more reasonable spot.