### PR TITLE
Fix: revert color0.a <= 0.5 to mirror original shader code and fix various light/shader regressions

### DIFF
--- a/E3/Full/shaders_shader_passes_shadow_shadow_apply_combined_1.psh
+++ b/E3/Full/shaders_shader_passes_shadow_shadow_apply_combined_1.psh
@@ -77,7 +77,7 @@ float4 main(
     r0 *= tex3.bbbb;
 
     
-    if (color0.a <= 0.0) {
+    if (color0.a <= 0.5) {
         r0 = 0;
     }
 

--- a/E3/Performance/shaders_shader_passes_shadow_shadow_apply_combined_1.psh
+++ b/E3/Performance/shaders_shader_passes_shadow_shadow_apply_combined_1.psh
@@ -70,7 +70,7 @@ float4 main(
     r0 *= tex3.bbbb;
 
     
-    if (color0.a <= 0.0) {
+    if (color0.a <= 0.5) {
         r0 = 0;
     }
 

--- a/Retail/Full/shaders_shader_passes_shadow_shadow_apply_combined_0.psh
+++ b/Retail/Full/shaders_shader_passes_shadow_shadow_apply_combined_0.psh
@@ -77,7 +77,7 @@ float4 main(
     r0 *= tex3.bbbb;
 
     
-    if (color0.a <= 0.0) {
+    if (color0.a <= 0.5) {
         r0 = 0;
     }
 

--- a/Retail/Performance/shaders_shader_passes_shadow_shadow_apply_combined_0.psh
+++ b/Retail/Performance/shaders_shader_passes_shadow_shadow_apply_combined_0.psh
@@ -70,7 +70,7 @@ float4 main(
     r0 *= tex3.bbbb;
 
     
-    if (color0.a <= 0.0) {
+    if (color0.a <= 0.5) {
         r0 = 0;
     }
 


### PR DESCRIPTION
The original Halo 2 shadow apply shaders include a check at the end of the files to cull the color0 alpha if it's below 0.5. Without this check, the lights produce artifacts including backwards light and gel casts.

The current version of the Halo 2 Custom Shaders lowers this value to 0.0, which also causes these regressions, and is responsible for the 'inconsistent' backwards light projection issues, as the change was only made on the combined_0/1-tap .psh files.

This PR reverts the behavior to follow the original Halo 2 shader, and resolves the related regressions. No other side effects or issues have been observed from testing.

Below is a comparison of the flickering flourescent at the start of Outskirts. First image is the shader value at 0.0, manifesting the regressions, while the image after is 0.5, with the regressions eliminated.
![lights-regressed](https://github.com/user-attachments/assets/234c58cd-3f19-4a86-b795-cba5332d1b8e)
![lights-fixed](https://github.com/user-attachments/assets/0655052f-1620-4862-9fa3-00162abed551)